### PR TITLE
fix defaultnormal_vertex monkey patch breaking all materials where USE_TANGENT is true

### DIFF
--- a/monkey-patch/defaultnormal_vertex.glsl.js
+++ b/monkey-patch/defaultnormal_vertex.glsl.js
@@ -25,7 +25,7 @@ module.exports = [
 	"#endif",
 
 	"#ifndef INSTANCE_UNIFORM",
-	
+
 		"vec3 transformedNormal =  transposeMat3( inverse( mat3( modelViewMatrix * _instanceMatrix ) ) ) * objectNormal ;",
 
 	"#else",
@@ -34,6 +34,42 @@ module.exports = [
 
 	"#endif",
 
-"#endif"
+"#endif",
+
+"#ifdef USE_TANGENT",
+
+	"#ifdef FLIP_SIDED",
+
+		"objectTangent = -objectTangent;",
+
+	"#endif",
+
+	"#ifndef INSTANCE_TRANSFORM",
+
+		"vec3 transformedTangent = normalMatrix * objectTangent;",
+
+	"#else",
+
+		"#ifndef INSTANCE_MATRIX",
+	
+			"mat4 _instanceMatrix = getInstanceMatrix();",
+	
+			"#define INSTANCE_MATRIX",
+	
+		"#endif",
+	
+		"#ifndef INSTANCE_UNIFORM",
+	
+			"vec3 transformedTangent =  transposeMat3( inverse( mat3( modelViewMatrix * _instanceMatrix ) ) ) * objectTangent;",
+	
+		"#else",
+	
+			"vec3 transformedTangent = ( modelViewMatrix * _instanceMatrix * vec4( objectTangent , 0.0 ) ).xyz;",
+	
+		"#endif",
+
+	"#endif",
+	
+"#endif",
 
 ].join("\n");

--- a/monkey-patch/defaultnormal_vertex.glsl.js
+++ b/monkey-patch/defaultnormal_vertex.glsl.js
@@ -9,12 +9,8 @@ module.exports = [
 	"objectNormal = -objectNormal;",
 
 "#endif",
-
-"#ifndef INSTANCE_TRANSFORM",
-
-	"vec3 transformedNormal = normalMatrix * objectNormal;",
-
-"#else",
+	
+"#ifdef INSTANCE_TRANSFORM",
 
 	"#ifndef INSTANCE_MATRIX ",
 
@@ -23,18 +19,24 @@ module.exports = [
 		"#define INSTANCE_MATRIX",
 
 	"#endif",
-
-	"#ifndef INSTANCE_UNIFORM",
-
-		"vec3 transformedNormal =  transposeMat3( inverse( mat3( modelViewMatrix * _instanceMatrix ) ) ) * objectNormal ;",
-
+	
+	"#ifdef INSTANCE_UNIFORM",
+	
+		"mat3 _normalTransformMatrix = mat3(modelViewMatrix * _instanceMatrix);",
+	
 	"#else",
-
-		"vec3 transformedNormal = ( modelViewMatrix * _instanceMatrix * vec4( objectNormal , 0.0 ) ).xyz;",
-
+	
+		"mat3 _normalTransformMatrix = transposeMat3( inverse( mat3( modelViewMatrix * _instanceMatrix ) ) );",
+	
 	"#endif",
+	
+"#else",
 
+	"mat3 _normalTransformMatrix = normalMatrix;",	
+	
 "#endif",
+	
+"vec3 transformedNormal = _normalTransformMatrix * objectNormal;",
 
 "#ifdef USE_TANGENT",
 
@@ -44,31 +46,7 @@ module.exports = [
 
 	"#endif",
 
-	"#ifndef INSTANCE_TRANSFORM",
-
-		"vec3 transformedTangent = normalMatrix * objectTangent;",
-
-	"#else",
-
-		"#ifndef INSTANCE_MATRIX",
-	
-			"mat4 _instanceMatrix = getInstanceMatrix();",
-	
-			"#define INSTANCE_MATRIX",
-	
-		"#endif",
-	
-		"#ifndef INSTANCE_UNIFORM",
-	
-			"vec3 transformedTangent =  transposeMat3( inverse( mat3( modelViewMatrix * _instanceMatrix ) ) ) * objectTangent;",
-	
-		"#else",
-	
-			"vec3 transformedTangent = ( modelViewMatrix * _instanceMatrix * vec4( objectTangent , 0.0 ) ).xyz;",
-	
-		"#endif",
-
-	"#endif",
+	"vec3 transformedTangent = _normalTransformMatrix * objectTangent;",
 	
 "#endif",
 


### PR DESCRIPTION
It looks like the defaultnormal_vertex patch didn't include any code for vertex tangents, which meant that *all* materials in the project which used vertex tangents were broken.

As a bonus, this should now support instancing objects with tangents as well. I've tested it and it seems to work fine.